### PR TITLE
[stable-2.x] Add Cargo.lock to dockerfiles (#501)

### DIFF
--- a/Dockerfile.amd64
+++ b/Dockerfile.amd64
@@ -41,7 +41,7 @@ WORKDIR /app
 FROM rust-builder AS fms-guardrails-orchestr8-builder
 ARG CONFIG_FILE=config/config.yaml
 
-COPY build.rs *.toml LICENSE /app/
+COPY build.rs *.toml Cargo.lock LICENSE /app/
 COPY ${CONFIG_FILE} /app/config/config.yaml
 COPY protos/ /app/protos/
 COPY src/ /app/src/

--- a/Dockerfile.ppc64le
+++ b/Dockerfile.ppc64le
@@ -50,7 +50,7 @@ RUN rustup component add rustfmt
 FROM rust-builder AS fms-guardrails-orchestr8-builder
 ARG CONFIG_FILE=config/config.yaml
 
-COPY build.rs *.toml LICENSE /app/
+COPY build.rs *.toml Cargo.lock LICENSE /app/
 COPY ${CONFIG_FILE} /app/config/config.yaml
 COPY protos/ /app/protos/
 COPY src/ /app/src/

--- a/Dockerfile.s390x
+++ b/Dockerfile.s390x
@@ -44,7 +44,7 @@ WORKDIR /app
 FROM rust-builder AS fms-guardrails-orchestr8-builder
 ARG CONFIG_FILE=config/config.yaml
 
-COPY build.rs *.toml LICENSE /app/
+COPY build.rs *.toml Cargo.lock LICENSE /app/
 COPY ${CONFIG_FILE} /app/config/config.yaml
 COPY protos/ /app/protos/
 COPY src/ /app/src/


### PR DESCRIPTION
(cherry picked from commit 3cc74c37d61e198443002e1d31698972e94675d2)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Improved container build reliability across all supported architectures by incorporating the dependency lockfile into the build process. This reduces version drift, ensures deterministic builds, and helps produce consistent binaries across platforms. No changes to runtime behavior or user workflows; expect more predictable releases and easier reproducibility when deploying or debugging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->